### PR TITLE
Fix unable to modify final fields with Java 12+.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ repositories {
 
 dependencies {
 	minecraft "net.minecraftforge:forge:${forge_version}"
-	runtimeOnly fg.deobf("curse.maven:ftb-essentials:${ftbessentials_file}")
+	runtimeOnly fg.deobf("curse.maven:ftb-essentials-410811:${ftbessentials_file}")
 }
 
 jar {


### PR DESCRIPTION
After Java 12, `Field.modifiers` was added to [`Reflection.fieldFilterMap`](https://github.com/AdoptOpenJDK/openjdk-jdk12u/blob/184fdaae009a148259ece4131c4a29d284d69f51/src/java.base/share/classes/jdk/internal/reflect/Reflection.java#L57) so that we cannot modify it by using reflection.
See https://stackoverflow.com/questions/61141836/change-static-final-field-in-java-12

```
[Server thread/INFO] [FTB Ranks/]: Loading command nodes...
[Server thread/INFO] [STDERR/]: [com.feed_the_beast.mods.ftbranks.impl.RankManagerImpl:initCommands:94]: java.lang.NoSuchFieldException: modifiers
[Server thread/INFO] [STDERR/]: [com.feed_the_beast.mods.ftbranks.impl.RankManagerImpl:initCommands:94]: 	at java.base/java.lang.Class.getDeclaredField(Class.java:2412)
[Server thread/INFO] [STDERR/]: [com.feed_the_beast.mods.ftbranks.impl.RankManagerImpl:initCommands:94]: 	at com.feed_the_beast.mods.ftbranks.impl.RankManagerImpl.initCommands(RankManagerImpl.java:86)
[Server thread/INFO] [STDERR/]: [com.feed_the_beast.mods.ftbranks.impl.RankManagerImpl:initCommands:94]: 	at com.feed_the_beast.mods.ftbranks.impl.FTBRanksAPIImpl.serverStarted(FTBRanksAPIImpl.java:59)
[Server thread/INFO] [STDERR/]: [com.feed_the_beast.mods.ftbranks.impl.RankManagerImpl:initCommands:94]: 	at net.minecraftforge.eventbus.ASMEventHandler_4_FTBRanksAPIImpl_serverStarted_FMLServerStartedEvent.invoke(.dynamic)
[Server thread/INFO] [STDERR/]: [com.feed_the_beast.mods.ftbranks.impl.RankManagerImpl:initCommands:94]: 	at net.minecraftforge.eventbus.ASMEventHandler.invoke(ASMEventHandler.java:85)
[Server thread/INFO] [STDERR/]: [com.feed_the_beast.mods.ftbranks.impl.RankManagerImpl:initCommands:94]: 	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:297)
[Server thread/INFO] [STDERR/]: [com.feed_the_beast.mods.ftbranks.impl.RankManagerImpl:initCommands:94]: 	at net.minecraftforge.fml.server.ServerLifecycleHooks.handleServerStarted(ServerLifecycleHooks.java:107)
[Server thread/INFO] [STDERR/]: [com.feed_the_beast.mods.ftbranks.impl.RankManagerImpl:initCommands:94]: 	at net.minecraft.server.MinecraftServer.func_240802_v_(MinecraftServer.java:621)
[Server thread/INFO] [STDERR/]: [com.feed_the_beast.mods.ftbranks.impl.RankManagerImpl:initCommands:94]: 	at net.minecraft.server.MinecraftServer.lambda$startServer$0(MinecraftServer.java:232)
[Server thread/INFO] [STDERR/]: [com.feed_the_beast.mods.ftbranks.impl.RankManagerImpl:initCommands:94]: 	at java.base/java.lang.Thread.run(Thread.java:830)
[Server thread/INFO] [FTB Ranks/]: Loaded 0 command nodes
```